### PR TITLE
Add presence indicator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,7 +190,7 @@ class App extends Component {
 
     const shareId = randomize("a0", 6, { exclude: "0oOiIlL1" });
     this.setState({shareId});
-    database.setShareId(shareId);
+    database.joinSharedTable(shareId, personalDataLabel);
 
     const updatedNewContext = await Codap.getDataContext(dataContextName);
     if (updatedNewContext) {
@@ -199,9 +199,9 @@ class App extends Component {
   }
 
   joinShare = async () => {
-    const shareId = this.state.joinShareId;
+    const {joinShareId: shareId, personalDataLabel} = this.state;
     this.setState({shareId});
-    database.setShareId(shareId);
+    database.joinSharedTable(shareId, personalDataLabel);
 
     const response = await database.getAll();
     const contextData = response && response.val();
@@ -252,6 +252,7 @@ class App extends Component {
       selectedDataContext: kNewSharedTable,
       personalDataLabel: ""
     });
+    database.leaveSharedTable();
   }
 }
 


### PR DESCRIPTION
This adds users to a `connectedUsers` list when they connect to a shared table, and removes them when they either leave the share or disconnect from the database.

This also adds a timestamp for when the user connected, as a (probably unneeded) future-friendly way to allow a clean-up function, if we ever find that users aren't being removed from the list.