### PR TITLE
TypeScript types for CODAP notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import React, { Component, ChangeEvent } from "react";
 import * as randomize from "randomatic";
 import { CodapHelper as Codap, DataContext} from "./lib/codap-helper";
-import "./App.css";
+import { ClientNotification } from "./lib/CodapInterface";
 import { DB } from "./lib/db";
+import "./App.css";
 
 const kPluginName = "Collaborative Data Sharing";
 const kVersion = "0.0.1";
@@ -139,7 +140,9 @@ class App extends Component {
     this.setState({availableDataContexts: contexts});
   }
 
-  handleDataContextUpdate = async () => {
+  handleDataContextUpdate = async (notification: ClientNotification) => {
+    const { action, resource, values } = notification;
+
     this.updateAvailableDataContexts(); // existing dataContext name may have changed
 
     const { shareId, selectedDataContext, personalDataLabel } = this.state;

--- a/src/lib/CodapInterface.ts
+++ b/src/lib/CodapInterface.ts
@@ -96,6 +96,13 @@ export interface CodapApiResponse {
  */
 var interactiveState = {};
 
+export interface ClientNotification {
+  action: string;
+  resource: string;
+  values: any;
+}
+export type ClientHandler = (notification: ClientNotification) => void;
+
 /**
  * A list of subscribers to messages from CODAP
  * @param {[{actionSpec: {RegExp}, resourceSpec: {RegExp}, handler: {function}}]}
@@ -356,7 +363,7 @@ const codapInterface = {
    *   'move', 'resize', .... If not specified, all operations will be reported.
    * @param handler {Function} A handler to receive the notifications.
    */
-  on: function (actionSpec: string, resourceSpec: string, operation: string | (() => void), handler?: () => void) {
+  on: function (actionSpec: string, resourceSpec: string, operation: string | ClientHandler, handler?: ClientHandler) {
     var as = 'notify',
         rs,
         os,

--- a/src/lib/codap-helper.ts
+++ b/src/lib/codap-helper.ts
@@ -1,4 +1,4 @@
-import codapInterface, { CodapApiResponse } from "./CodapInterface";
+import codapInterface, { CodapApiResponse, ClientHandler } from "./CodapInterface";
 
 export interface DataContext {
   name: string;
@@ -21,11 +21,11 @@ export class CodapHelper {
     return await codapInterface.init(interfaceConfig);
   }
 
-  static addDataContextsListListener(callback: () => void) {
+  static addDataContextsListListener(callback: ClientHandler) {
     codapInterface.on("notify", "documentChangeNotice", callback);
   }
 
-  static addDataContextChangeListener(context: DataContext, callback: () => void) {
+  static addDataContextChangeListener(context: DataContext, callback: ClientHandler) {
     codapInterface.on("notify", `dataContextChangeNotice[${context.name}]`, callback);
   }
 


### PR DESCRIPTION
In the interest of keeping PRs small to avoid merge conflicts or duplicate work, this makes it easier to respond to CODAP notifications but doesn't actually do anything with them yet.